### PR TITLE
ci: drop i686 wheels

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,21 +36,7 @@ matrix:
         - UNICODE_WIDTH=16
     - os: linux
       env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=2.7
-        - PLAT=i686
-        - UNICODE_WIDTH=16
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.5
-        - NP_BUILD_DEP="1.9.3"
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.5
-        - PLAT=i686
         - NP_BUILD_DEP="1.9.3"
     - os: linux
       env:
@@ -58,18 +44,8 @@ matrix:
         - NP_BUILD_DEP="1.9.3"
     - os: linux
       env:
-        - MB_PYTHON_VERSION=3.6
-        - PLAT=i686
-        - NP_BUILD_DEP="1.9.3"
-    - os: linux
-      env:
         - MB_PYTHON_VERSION=3.7
         - NP_BUILD_DEP=1.14.5
-    - os: linux
-      env:
-        - MB_PYTHON_VERSION=3.7
-        - NP_BUILD_DEP=1.14.5
-        - PLAT=i686
     - os: osx
       osx_image: xcode8
       language: objective-c


### PR DESCRIPTION
These wheels are not frequently used and building these wheels is a
burden for the CI infrastructure.