### PR TITLE
fix: updates for Stan 2.19, many changes

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "multibuild"]
 	path = multibuild
-	url = https://github.com/matthew-brett/multibuild.git
+	url = https://github.com/riddell-stan/multibuild
 [submodule "pystan"]
 	path = pystan
 	url = https://github.com/stan-dev/pystan

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 env:
     global:
         - REPO_DIR=pystan
-        - BUILD_COMMIT=v2.18.1.0
+        - BUILD_COMMIT=v2.19.0.0
         - BUILD_DEPENDS=Cython
         - TEST_DEPENDS=
         - PLAT=x86_64
@@ -9,6 +9,8 @@ env:
         - NP_BUILD_DEP=1.8.2
         - WHEELHOUSE_UPLOADER_USERNAME=pystan-worker
         - WHEELHOUSE_UPLOADER_REGION=IAD
+        # custom manylinux image with newer gcc
+        - DOCKER_IMAGE=tktechdocker/manylinux:gcc8.3.0
         # Following generated with
         # travis encrypt -r stan-dev/pystan-wheels WHEELHOUSE_UPLOADER_SECRET=<the api key>
         - secure: "RPK/AsxmDNiiJ5WZwRr8oN5Ybj+/IaCNp/zF8ZwOO4XXG0RF56n1fGeqW+tfHhsOjjwBZtYmQSqSDrcd3cQw564yoBpbTy1YIFPMVP5gELFE4xw9A7KGOcGJ22RMNbqAq4esl8YqOLVjLsFQbx0aCrcRripnj0tjK/6nOemYt6+Oo8rm2SZjRnclmE7UsVSoYYll/cE+H/wTLZo3nHnRl6JZUcTa5dQ6i/GUR+kMzA7u4yGI6n16THeBIVI6dAOgabmInahZad6v7EwUWGZrwUHBmQmZhqMkPU9YVEd3I4MUgJ/9acl4ezlQuEZ4CfagSKqWMUpa1nqjsuNf374wZRi3jv4urTd6ouk+32TkFBQDHrBpdSCRgzn1Vp9Pogs4sThIgUOSEDx90nS9lhmQ5EFm8fIz2W4h1Relo0ra+FKvahIBpMCSW20Ozty4GiyY4bIYt9vzSZCblp5HlxWF5UW1zRIExtJvSipSEHElk8SvFryunFacqt2T36OeaYhp2mA5LGqTcNWMTTNsM4Z0Vw7CzeB9KOgTT1FRKVjM9oiVO9blAj0TkseBYnR0PuQ6EdHmNq8bO+oupaafca/cq6j7GRiv5n7pL66LV75xv+8gQ4VpLY6Z31+DRZ74eh/nobsIJobYz6H5N8wjhuGZAtMHIeisZrdjWLOGiqGa9KY="

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,6 @@ language: python
 cache:
   - pip
 python: 3.5
-sudo: required
 dist: trusty
 services: docker
 
@@ -54,13 +53,11 @@ matrix:
       env:
         - MB_PYTHON_VERSION=2.7
     - os: osx
-      osx_image: xcode8
       language: objective-c
       env:
         - MB_PYTHON_VERSION=3.5
         - NP_BUILD_DEP="1.9.3"
     - os: osx
-      osx_image: xcode8
       language: objective-c
       env:
         - MB_PYTHON_VERSION=3.6
@@ -79,6 +76,16 @@ before_install:
 install:
     # Maybe get and clean and patch source
     - clean_code $REPO_DIR $BUILD_COMMIT
+    # remove unused files from pystan/pystan/stan to save space and avoid problems on manylinux1
+    # these cleaning steps may be removed after manylinux1 is retired. See this issue for more:
+    # https://github.com/pypa/auditwheel/issues/145
+    # cleanup steps start
+    - find pystan/pystan/stan/lib -type d -iname doc -print0 | xargs -0 rm -rf
+    - find pystan/pystan/stan/lib/stan_math/lib -type d -name test -print0 | xargs -0 rm -rf
+    - find pystan/pystan/stan/lib/stan_math/lib -maxdepth 2 -type d -name libs -print0 | xargs -0 rm -rf
+    - find pystan/pystan/stan/lib/stan_math/lib -maxdepth 2 -type d -name tools -print0 | xargs -0 rm -rf
+    # cleanup steps end
+    # osx wheels take a particularly long time to build
     - travis_wait 40 build_wheel $REPO_DIR $PLAT
 
 script:

--- a/README.rst
+++ b/README.rst
@@ -10,5 +10,8 @@ all works.
 
 *Differences from the standard ``multibuild`` instructions are noted in this section.**
 
-Stan version 2.18 and higher requires C++11. In ``env_vars.sh`` we ``export MACOSX_DEPLOYMENT_TARGET=10.9``
+Stan version 2.19 and higher requires C++14. In ``env_vars.sh`` we ``export MACOSX_DEPLOYMENT_TARGET=10.9``
 so that ``clang`` will use ``libc++`` for the C++ standard library.
+
+We also use a custom `xenial` image because to even test pystan we need a
+version of gcc more recent than the one that ships with trusty.

--- a/env_vars.sh
+++ b/env_vars.sh
@@ -1,2 +1,5 @@
 # See multibuild/README.rst
 export MACOSX_DEPLOYMENT_TARGET=10.9
+export CFLAGS="-static-libstdc++"
+export CC=/usr/local/gcc-8.3.0/bin/gcc-8.3.0
+export CXX=/usr/local/gcc-8.3.0/bin/g++-8.3.0


### PR DESCRIPTION
- Use a custom manylinux image which has a newer version of gcc.
- Use a custom text runner image (riddellstan/xenial) instead of
matthewbrett/trusty, again for a newer version of gcc.