### PR TITLE
Build wheels for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,6 +47,10 @@ matrix:
       env:
         - MB_PYTHON_VERSION=3.7
         - NP_BUILD_DEP=1.14.5
+    - os: linux
+      env:
+        - MB_PYTHON_VERSION=3.8
+        - NP_BUILD_DEP=1.14.5
     - os: osx
       language: objective-c
       env:
@@ -65,6 +69,11 @@ matrix:
       language: generic
       env:
         - MB_PYTHON_VERSION=3.7
+        - NP_BUILD_DEP=1.14.5
+    - os: osx
+      language: generic
+      env:
+        - MB_PYTHON_VERSION=3.8
         - NP_BUILD_DEP=1.14.5
 before_install:
     - BUILD_DEPENDS="numpy==$NP_BUILD_DEP ${BUILD_DEPENDS}"


### PR DESCRIPTION
Python 3.8 was [released on October 14th, 2019](https://docs.python.org/3/whatsnew/3.8.html).

I am not sure why pystan-wheels uses a [private git submodule for multibuild](https://github.com/riddell-stan/multibuild/tree/c40a01c595b8bb09b3be8829b857437523009042), but official [multibuild](https://github.com/matthew-brett/multibuild) supports building wheels for Python 3.8. So ideally this should be the only change required.