### PR TITLE
Build wheels for Python 3.9

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,10 @@ jobs:
     env:
       - MB_PYTHON_VERSION=3.8
       - NP_BUILD_DEP=1.14.5
+  - os: linux
+    env:
+      - MB_PYTHON_VERSION=3.9
+      - NP_BUILD_DEP=1.14.5
   - os: osx
     language: objective-c
     env:
@@ -51,6 +55,11 @@ jobs:
     language: generic
     env:
       - MB_PYTHON_VERSION=3.8
+      - NP_BUILD_DEP=1.14.5
+  - os: osx
+    language: generic
+    env:
+      - MB_PYTHON_VERSION=3.9
       - NP_BUILD_DEP=1.14.5
 before_install:
   - BUILD_DEPENDS="numpy==$NP_BUILD_DEP ${BUILD_DEPENDS}"


### PR DESCRIPTION
Python 3.9 was [released on October 5th, 2020](https://www.python.org/downloads/release/python-390/).

The official [multibuild](https://github.com/matthew-brett/multibuild) supports building wheels for Python 3.9. So ideally this should be the only change required.